### PR TITLE
Respect existing task family when creating new one

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	futureDef := &ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: taskDesc.TaskDefinition.ContainerDefinitions,
-		Family:               appName,
+		Family:               taskDesc.TaskDefinition.Family,
 		Volumes:              taskDesc.TaskDefinition.Volumes,
 		NetworkMode:          taskDesc.TaskDefinition.NetworkMode,
 		TaskRoleArn:          taskDesc.TaskDefinition.TaskRoleArn,


### PR DESCRIPTION
This ensures the service being updated uses the same task family as the previous
one.
