### PR TITLE
Add a note re: deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # go-ecs-deploy [![Build Status](https://travis-ci.org/vend/go-ecs-deploy.svg)](https://travis-ci.org/vend/go-ecs-deploy)
-deploy a hosted docker container to an existing ecs cluster
+~~deploy a hosted docker container to an existing ecs cluster~~
 
-Allows deployment of ECS microservices straight from the command line!
+~~Allows deployment of ECS microservices straight from the command line!~~
+
+Note that **go-ecs-deploy** has been deprecated in favor of using [catapult](https://github.com/vend/catapult), as is done in the standard Travis CI/CD [deploy script](https://github.com/vend/ci-scripts/blob/master/travis/deploy.sh#L53).
 
 ## Installation
 


### PR DESCRIPTION
Edit the text to state that this tool has been deprecated in favor
of catapult. Click for [rendered](https://github.com/vend/go-ecs-deploy/blob/30a1415dc4982fec031eca8c320a4c4612f74e28/README.md) view.

<img src="https://media3.giphy.com/media/3o7TKLy0He9SYe8niE/giphy.gif"/>